### PR TITLE
Update vespucci URL

### DIFF
--- a/project_list.txt
+++ b/project_list.txt
@@ -37,7 +37,7 @@ scout_routing https://raw.githubusercontent.com/mvexel/taginfo-scout/master/tele
 townlands_ie http://www.townlands.ie/taginfo.json
 unterkunftskarte http://unterkunftskarte.de/unterkunftskarte.json
 valhalla https://raw.githubusercontent.com/valhalla/conf/master/taginfo.json
-vespucci https://osmeditor4android.googlecode.com/svn/trunk/taginfo.json
+vespucci https://raw.githubusercontent.com/MarcusWolschon/osmeditor4android/master/taginfo.json
 waymarkedtrails http://mapstatic.waymarkedtrails.org/taginfo.json
 wikidata_org http://tools.wmflabs.org/wp-world/wikidata/tags.php
 wuzzelmap http://wuzzelmap.ck.si/taginfo.json


### PR DESCRIPTION
vspucci moved to github a longish time ago, new link and updated contents.