### PR TITLE
add Keys used in german mapnik style

### DIFF
--- a/project_list.txt
+++ b/project_list.txt
@@ -46,3 +46,4 @@ waymarkedtrails http://mapstatic.waymarkedtrails.org/taginfo.json
 wikidata_org http://tools.wmflabs.org/wp-world/wikidata/tags.php
 wuzzelmap http://wuzzelmap.ck.si/taginfo.json
 yohours http://github.pavie.info/yohours/taginfo.json
+osm_carto_de https://raw.githubusercontent.com/giggls/openstreetmap-carto-de/master/views_osmde/taginfo.json


### PR DESCRIPTION
Hi Jochen,

I just added a taginfo.json whith all the keys used in (new) german mapnik style.
Unfortunately this will only have the keys used because I would need to parse sql to
also provide the values. However I think this is better than nothing :)