### PR TITLE
New location of OSMaxx taginfo project JSON file

### DIFF
--- a/project_list.txt
+++ b/project_list.txt
@@ -32,7 +32,7 @@ osm_inspector_addresses https://raw.githubusercontent.com/ltog/osmi-addresses/ma
 osm_inspector_public_transport_railways http://tools.geofabrik.de/osmi/osmi_pubtrans_railways.json
 osm_inspector_public_transport_stops http://tools.geofabrik.de/osmi/osmi_pubtrans_stops.json
 osm_mug https://raw.githubusercontent.com/joto/taginfo-projects/master/osm-mug/osm-mug.json
-osmaxx https://raw.githubusercontent.com/geometalab/osmaxx-docs/master/osmaxx.json
+osmaxx https://raw.githubusercontent.com/geometalab/osmaxx/master/docs/schema/osmaxx_taginfo.json
 osmbot https://raw.githubusercontent.com/Xevib/osmbot/master/taginfo/taginfo.json
 osmbuildings http://osmbuildings.org/ref/taginfo.json
 osmcoastline https://raw.githubusercontent.com/osmcode/osmcoastline/master/taginfo.json


### PR DESCRIPTION
Also with completely new content, generated from [`geometalab/osmaxx`'s `docs/schema/osmaxx_schema.yaml`](https://github.com/geometalab/osmaxx/blob/master/docs/schema/osmaxx_schema.yaml) with [`docs/schema/yaml_to_taginfo.py`](https://github.com/geometalab/osmaxx/blob/master/docs/schema/yaml_to_taginfo.py) as announced in https://github.com/geometalab/osmaxx-docs/pull/4#issuecomment-245941282