### PR TITLE
Update osmand to https

### DIFF
--- a/project_list.txt
+++ b/project_list.txt
@@ -43,7 +43,7 @@ osm_inspector_public_transport_railways http://tools.geofabrik.de/osmi/osmi_pubt
 osm_inspector_public_transport_stops http://tools.geofabrik.de/osmi/osmi_pubtrans_stops.json
 osm_mug https://raw.githubusercontent.com/taginfo/taginfo-projects/master/osm-mug/osm-mug.json
 osm_transit_extractor https://raw.githubusercontent.com/CanalTP/osm-transit-extractor/master/taginfo.json
-osmand http://builder.osmand.net:8080/view/WebSite/job/OsmAndTagInfo/ws/taginfo.json
+osmand https://builder.osmand.net:8080/view/WebSite/job/OsmAndTagInfo/ws/taginfo.json
 osmaxx https://raw.githubusercontent.com/geometalab/osmaxx/master/docs/schema/osmaxx_taginfo.json
 osmbot https://raw.githubusercontent.com/Xevib/osmbot/master/taginfo/taginfo.json
 osmbuildings http://osmbuildings.org/ref/taginfo.json


### PR DESCRIPTION
With https://github.com/osmandapp/OsmAnd-tools/issues/311 closed, OsmAnd can return.