### PR TITLE
Adding babykarte to Taginfo

### DIFF
--- a/project_list.txt
+++ b/project_list.txt
@@ -1,4 +1,5 @@
 architects_in_osm https://osm.ascolteo.fr/taginfo.json
+babykarte https://raw.githubusercontent.com/babykarte/babykarte.github.io/master/taginfo.json
 bano https://bano.openstreetmap.fr/bano_taginfo.json
 bikecitizens https://raw.githubusercontent.com/BikeCitizens/bikecitizens-taginfo/master/bikecitizens-routing.json
 boxlocator https://boxlocator.eu/boxlocator_taginfo.json


### PR DESCRIPTION
We'd like to have Babykarte added to the Taginfo database.

Working website: https://babykarte.github.io/