### PR TITLE
Add CyclOSM to project list

### DIFF
--- a/project_list.txt
+++ b/project_list.txt
@@ -8,6 +8,7 @@ cartovrac https://raw.githubusercontent.com/vivreanantes/cartovrac/master/taginf
 checkautopista https://k1wiosm.github.io/checkautopista2/taginfo.json
 closely https://raw.githubusercontent.com/julienrf/closely/master/taginfo.json
 cosmogony https://raw.githubusercontent.com/osm-without-borders/cosmogony/master/taginfo.json
+cyclosm https://raw.githubusercontent.com/cyclosm/cyclosm-cartocss-style/master/taginfo.json
 dianacht_topo https://geo.dianacht.de/topo/taginfo.json
 direction https://raw.githubusercontent.com/osmtools/direction/master/taginfo.json
 geofabrik_free_shapes https://download.geofabrik.de/taginfo-free-shapes.json


### PR DESCRIPTION
Hi,

CyclOSM is a bike-oriented CartoCSS render, see https://github.com/cyclosm/cyclosm-cartocss-style.

This commits adds the taginfo file generated by the project to the taginfo-projects list.

Best,