### PR TITLE
Add JSON schema for projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 
 This repository contains the list of projects for taginfo. See
 
+* [JSON schema](https://github.com/taginfo/taginfo-projects/blob/master/taginfo-project-schema.json)
 * [Description on Wiki](https://wiki.openstreetmap.org/wiki/Taginfo/Projects)
 * [Projects table](https://taginfo.openstreetmap.org/projects)
 * [Fetch status table](https://taginfo.openstreetmap.org/taginfo/projects)

--- a/taginfo-project-schema.json
+++ b/taginfo-project-schema.json
@@ -1,0 +1,126 @@
+{
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "$ref": "#/definitions/Taginfo",
+  "definitions": {
+    "Taginfo": {
+      "title": "Taginfo",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "data_format": {
+          "type": "integer",
+          "description": "data format version, currently always 1, will get updated if there are incompatible changes to the format"
+        },
+        "data_url": {
+          "type": "string",
+          "format": "uri",
+          "description": "the URL under which this project file can be accessed"
+        },
+        "data_updated": {
+          "type": "string",
+          "pattern": "20\\d{2}\\d{2}\\d{2}T\\d{2}\\d{2}\\d{2}Z",
+          "description": "yyyymmddThhmmssZ timestamp when project file was updated"
+        },
+        "project": {
+          "$ref": "#/definitions/Project"
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Tag"
+          }
+        }
+      },
+      "required": ["data_format", "project", "tags"]
+    },
+    "Project": {
+      "title": "Project",
+      "type": "object",
+      "description": "meta information about the project",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "name of the project"
+        },
+        "description": {
+          "type": "string",
+          "description": "short description of the project"
+        },
+        "project_url": {
+          "type": "string",
+          "format": "uri",
+          "description": "homepage of the project with general information"
+        },
+        "doc_url": {
+          "type": "string",
+          "format": "uri",
+          "description": "documentation of the project and especially the tags used"
+        },
+        "icon_url": {
+          "type": "string",
+          "format": "uri",
+          "description": "project logo, should work in 16x16 pixels on white and light gray backgrounds"
+        },
+        "contact_name": {
+          "type": "string",
+          "description": "contact name (needed for taginfo maintainer)"
+        },
+        "contact_email": {
+          "type": "string",
+          "format": "email",
+          "description": "contact email (needed for taginfo maintainer)"
+        }
+      },
+      "required": [
+        "name",
+        "description",
+        "project_url",
+        "contact_name",
+        "contact_email"
+      ]
+    },
+    "Tag": {
+      "title": "Tag",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "key": {
+          "type": "string",
+          "description": "OSM tag key"
+        },
+        "value": {
+          "type": "string",
+          "description": "OSM tag value (if not supplied it means 'all values')"
+        },
+        "object_types": {
+          "type": "array",
+          "description": "OSM object types this key/tag can be used for",
+          "items": {
+            "$ref": "#/definitions/ObjectType"
+          }
+        },
+        "description": {
+          "type": "string",
+          "description": "how the key/tag is used in this project"
+        },
+        "doc_url": {
+          "type": "string",
+          "format": "uri",
+          "description": "link to further documentation of the project about this specific key/tag"
+        },
+        "icon_url": {
+          "type": "string",
+          "format": "uri",
+          "description": "URL of an icon, should work in 16x16 pixels on white and light gray backgrounds"
+        }
+      },
+      "required": ["key"]
+    },
+    "ObjectType": {
+      "title": "ObjectType",
+      "type": "string",
+      "enum": ["node", "way", "relation", "area"]
+    }
+  }
+}

--- a/test_changes
+++ b/test_changes
@@ -62,6 +62,15 @@ do
         if [ $? == 0 ]
         then
             echo -e "${ansi_color_green}-- taginfo.json is valid JSON${ansi_color_reset}"
+            python -m jsonschema --instance "$tempdir/taginfo.json" taginfo-project-schema.json
+            if [ $? == 0 ]
+            then
+                echo -e "${ansi_color_green}-- taginfo.json validates against JSON schema${ansi_color_reset}"
+            else
+                echo "" 1>&2
+                echo -e "${ansi_color_red}-- taginfo.json does not validate against JSON schema${ansi_color_reset}" 1>&2
+                exit_code=$((exit_code+1))
+            fi
         else
             echo "" 1>&2
             echo -e "${ansi_color_red}-- taginfo.json is not valid JSON${ansi_color_reset}" 1>&2


### PR DESCRIPTION
The compiled JSON schema is based on the specification on https://wiki.openstreetmap.org/wiki/Taginfo/Projects

It permits automatic testing of the supplied projects, e.g. using [python-jsonschema](https://pypi.org/project/jsonschema/)