### PR TITLE
Add osmlab/tag2link

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,8 @@
+language: python
+python:
+  - "3.8"
+install:
+  - pip3 install jsonschema
 
 script:
-    - ./test_changes
-
+  - ./test_changes

--- a/project_list.txt
+++ b/project_list.txt
@@ -79,6 +79,7 @@ scout_rendering https://raw.githubusercontent.com/mvexel/taginfo-scout/master/te
 scout_routing https://raw.githubusercontent.com/mvexel/taginfo-scout/master/telenav_style.json
 slovenia_address_import https://raw.githubusercontent.com/openstreetmap-si/GursAddressesForOSM/master/taginfo.json
 streetcomplete https://goldfndr.github.io/StreetCompleteJSON/taginfo.json
+tag2link https://raw.githubusercontent.com/osmlab/tag2link/master/taginfo.json
 townlands_ie https://www.townlands.ie/taginfo.json
 traffic_signs_afr https://raw.githubusercontent.com/yopaseopor/beta_style_josm/master/taginfo/taginfo_afr.json
 traffic_signs_ame https://raw.githubusercontent.com/yopaseopor/beta_style_josm/master/taginfo/taginfo_ame.json


### PR DESCRIPTION
https://github.com/osmlab/tag2link – Formatter URLs for OpenStreetMap tags

Relates to https://github.com/taginfo/taginfo/issues/277, https://github.com/osmlab/tag2link/commit/f823b45dffae42276dc8f8fafe1cd8113e903ae5