### PR TITLE
Someone else style

### DIFF
--- a/project_list.txt
+++ b/project_list.txt
@@ -72,7 +72,7 @@ raba_kgz_import https://raba.openstreetmap.si/taginfo.json
 scout_rendering https://raw.githubusercontent.com/mvexel/taginfo-scout/master/telenav_style_rendering.json
 scout_routing https://raw.githubusercontent.com/mvexel/taginfo-scout/master/telenav_style.json
 slovenia_address_import https://raw.githubusercontent.com/openstreetmap-si/GursAddressesForOSM/master/taginfo.json
-someoneelse-style https://raw.githubusercontent.com/SomeoneElseOSM/SomeoneElse-style/master/taginfo.json
+someoneelse_style https://raw.githubusercontent.com/SomeoneElseOSM/SomeoneElse-style/master/taginfo.json
 streetcomplete https://goldfndr.github.io/StreetCompleteJSON/taginfo.json
 tag2link https://raw.githubusercontent.com/osmlab/tag2link/master/taginfo.json
 townlands_ie https://www.townlands.ie/taginfo.json

--- a/project_list.txt
+++ b/project_list.txt
@@ -72,6 +72,7 @@ raba_kgz_import https://raba.openstreetmap.si/taginfo.json
 scout_rendering https://raw.githubusercontent.com/mvexel/taginfo-scout/master/telenav_style_rendering.json
 scout_routing https://raw.githubusercontent.com/mvexel/taginfo-scout/master/telenav_style.json
 slovenia_address_import https://raw.githubusercontent.com/openstreetmap-si/GursAddressesForOSM/master/taginfo.json
+someoneelse-style https://raw.githubusercontent.com/SomeoneElseOSM/SomeoneElse-style/master/taginfo.json
 streetcomplete https://goldfndr.github.io/StreetCompleteJSON/taginfo.json
 tag2link https://raw.githubusercontent.com/osmlab/tag2link/master/taginfo.json
 townlands_ie https://www.townlands.ie/taginfo.json


### PR DESCRIPTION
SomeoneElse-style is an "England and Wales rural pedestrian" focused OSM-based map style. Example at https://map.atownsend.org.uk/maps/map/map.html . This taginfo.json is currently based on the tag preprocessing part of the style. 