### PR TITLE
add New Zealand address import

### DIFF
--- a/project_list.txt
+++ b/project_list.txt
@@ -58,6 +58,7 @@ matekarte https://gitlab.com/Strubbl/matekate/-/raw/master/taginfo.json
 maxheight_map https://raw.githubusercontent.com/mmd-osm/osm-maxheight-map/master/taginfo.json
 name_suggestion_index https://raw.githubusercontent.com/osmlab/name-suggestion-index/master/dist/taginfo.json
 nominatim https://nominatim.openstreetmap.org/taginfo.json
+nz_address_import https://raw.githubusercontent.com/osm-nz/linz-address-import/main/taginfo.json
 openadvertmap https://openadvertmap.pavie.info/taginfo.json
 openbeermap https://openbeermap.github.io/taginfo.json
 openinframap https://openinframap.org/taginfo.json


### PR DESCRIPTION
The [New Zealand address import project](https://wiki.openstreetmap.org/wiki/Import/New_Zealand_Street_Addresses_(2021)) compares street address data in OSM every week with government data (from [Land Information New Zealand](https://data.linz.govt.nz/layer/53353)).

It uses these tags to conflate the data, and updates the value of these tags where required. 