### PR TITLE
iD presets have moved to id-tagging-schema

### DIFF
--- a/project_list.txt
+++ b/project_list.txt
@@ -21,7 +21,7 @@ geofabrik_free_shapes https://download.geofabrik.de/taginfo-free-shapes.json
 hackerspaces_map https://www.technomancy.org/osm-hackerspaces/taginfo.json
 historic_place http://gk.historic.place/taginfo/historic.place.json
 histosm https://histosm.org/taginfo.json
-id_editor https://raw.githubusercontent.com/openstreetmap/iD/release/dist/data/taginfo.min.json
+id_editor https://raw.githubusercontent.com/openstreetmap/id-tagging-schema/main/dist/taginfo.min.json
 indoorequal https://raw.githubusercontent.com/indoorequal/indoorequal/master/taginfo.json
 josm_external_presets https://josm.openstreetmap.de/download/taginfo/taginfo_external_presets.json
 josm_main_mappaint_style https://josm.openstreetmap.de/download/taginfo/taginfo_style.json


### PR DESCRIPTION
openstreetmap/iD#8175 moved the iD editor’s project file to the [openstreetmap/id-tagging-schema](https://github.com/openstreetmap/id-tagging-schema/) repository, where it can be more easily reused by other projects such as Go Map!! and Overpass turbo.

Fixes openstreetmap/iD#8704.