### PR TITLE
Add two projects from Sven Geggus

### DIFF
--- a/project_list.txt
+++ b/project_list.txt
@@ -82,6 +82,8 @@ nominatim https://nominatim.openstreetmap.org/taginfo.json
 nz_address_import https://raw.githubusercontent.com/osm-nz/linz-address-import/main/taginfo.json
 openadvertmap https://openadvertmap.pavie.info/taginfo.json
 openbeermap https://openbeermap.github.io/taginfo.json
+openbrewerymap https://raw.githubusercontent.com/giggls/openbrewmap/master/taginfo.json
+opencampingmap https://raw.githubusercontent.com/giggls/opencampsitemap/master/taginfo.json
 openetymologymap https://www.dsantini.it/etymology/taginfo.json
 openinframap https://openinframap.org/taginfo.json
 opening_hours_evaluation_tool https://raw.githubusercontent.com/opening-hours/opening_hours.js/master/taginfo.json


### PR DESCRIPTION
Hello Jochen,

I made a first version of taginfo.json for my two projects.

Am I right in the assumption that it is currently not possible to specify tag combinations?

E.g. if I wanted to make **OpenPizzaMap** I would pecify **cuisine=pizza** but am currently unable to express that this is only rendered in combination with **amenity=restaurant** or **amenity=fast_food**?

Sven

