### PR TITLE
new streetcomplete taginfo source

### DIFF
--- a/project_list.txt
+++ b/project_list.txt
@@ -132,7 +132,7 @@ scout_rendering https://raw.githubusercontent.com/mvexel/taginfo-scout/master/te
 scout_routing https://raw.githubusercontent.com/mvexel/taginfo-scout/master/telenav_style.json
 slovenia_address_import https://raw.githubusercontent.com/openstreetmap-si/GursAddressesForOSM/master/taginfo.json
 someoneelse_style https://raw.githubusercontent.com/SomeoneElseOSM/SomeoneElse-style/master/taginfo.json
-streetcomplete https://goldfndr.github.io/StreetCompleteJSON/taginfo.json
+streetcomplete https://raw.githubusercontent.com/matkoniecz/Zazolc/taginfo/res/documentation/taginfo_listing_of_tags_added_or_edited_by_StreetComplete.json
 tag2link https://raw.githubusercontent.com/osmlab/tag2link/master/taginfo.json
 townlands_ie https://www.townlands.ie/taginfo.json
 traffic_signs_afr https://raw.githubusercontent.com/yopaseopor/beta_style_josm/master/taginfo/taginfo_afr.json


### PR DESCRIPTION
It is not yet reviewed by other (neither code nor data) but it is substantially superior to the current resource

Maybe in future it will be merged into StreetComplete itself and link will change, but it can take some time (especially as generator is a gigantic pile of hacks and hardcoded answers and magic and is parsing StreetComplete itself)

Generator is at https://github.com/matkoniecz/Zazolc/blob/taginfo/buildSrc/src/main/java/UpdateTaginfoListingTask.kt if anyone is curious - code review is welcome (I will submit it as a PR to StreetComplete repo, but first I will review it with help of someone else unfamiliar with SC)