### PR TITLE
Add an entry for the Usage Bot on Wikimedia Commons

### DIFF
--- a/project_list.txt
+++ b/project_list.txt
@@ -153,6 +153,7 @@ traffic_signs_pac https://raw.githubusercontent.com/yopaseopor/beta_style_josm/m
 umweltzone https://raw.githubusercontent.com/Umweltzone/Umweltzone/master/openstreetmap-taginfo/taginfo.json
 unroll https://raw.githubusercontent.com/Jungle-Bus/unroll/master/taginfo.json
 unterkunftskarte http://unterkunftskarte.de/unterkunftskarte.json
+usage_bot_commons https://raw.githubusercontent.com/bjh21/usage-bot/main/taginfo-commons.json
 valhalla https://raw.githubusercontent.com/valhalla/valhalla/master/taginfo.json
 veggiekarte https://raw.githubusercontent.com/piratenpanda/veggiekarte/master/data/taginfo.json
 vespucci https://raw.githubusercontent.com/MarcusWolschon/osmeditor4android/master/taginfo.json


### PR DESCRIPTION
I have a bot on Wikimedia Commons that fetches data from OpenStreetMap (actually from Taginfo) to keep track of which files on Commons are used on OpenStreetMap.