### PR TITLE
add PTNA to project list

### DIFF
--- a/project_list.txt
+++ b/project_list.txt
@@ -137,6 +137,7 @@ osrm https://raw.githubusercontent.com/Project-OSRM/osrm-backend/master/taginfo.
 parking_lanes https://raw.githubusercontent.com/zlant/parking-lanes/master/taginfo.json
 polygon_features https://raw.githubusercontent.com/tyrasd/osmtogeojson/taginfo/project.json
 prism https://raw.githubusercontent.com/Jungle-Bus/prism/main/docs/taginfo.json
+ptna https://ptna.openstreetmap.de/taginfo.json
 raba_kgz_import https://raba.openstreetmap.si/taginfo.json
 scout_rendering https://raw.githubusercontent.com/mvexel/taginfo-scout/master/telenav_style_rendering.json
 scout_routing https://raw.githubusercontent.com/mvexel/taginfo-scout/master/telenav_style.json


### PR DESCRIPTION
PTNA provides a [daily analysis](https://ptna.openstreetmap.de/en/statistics.php) of public transport lines mapped in OSM.
PTNA also provides an analysis of GTFS data.