### PR TITLE
Add Cycling QA map

### DIFF
--- a/project_list.txt
+++ b/project_list.txt
@@ -15,6 +15,7 @@ checkautopista https://k1wiosm.github.io/checkautopista2/taginfo.json
 ciclovia_bogota https://raw.githubusercontent.com/MaptimeBogota/Varios/master/proyecto-ciclovia/taginfo.json
 closely https://raw.githubusercontent.com/julienrf/closely/master/taginfo.json
 cosmogony https://raw.githubusercontent.com/osm-without-borders/cosmogony/master/taginfo.json
+cycling_qa https://github.com/britiger/openmaptiles-cycling-qa-deploy/raw/main/webmap/taginfo.json
 cyclosm https://raw.githubusercontent.com/cyclosm/cyclosm-cartocss-style/master/taginfo.json
 dianacht_topo https://geo.dianacht.de/topo/taginfo.json
 direction https://raw.githubusercontent.com/osmtools/direction/master/taginfo.json


### PR DESCRIPTION
Adding https://cycling-qa.lorenz.lu to taginfo for cycling qa, only special added tags to default vector map.