### PR TITLE
Remove openvegemap

### DIFF
--- a/project_list.txt
+++ b/project_list.txt
@@ -133,7 +133,6 @@ opensnowmap_org https://www.opensnowmap.org/opensnowmap_taginfo.json
 openstop https://raw.githubusercontent.com/OPENER-next/OpenStop-taginfo/main/taginfo.json
 opentopomap https://raw.githubusercontent.com/der-stefan/OpenTopoMap/master/mapnik/taginfo.json
 opentrailstash https://open.trailsta.sh/taginfo.json
-openvegemap https://raw.githubusercontent.com/Rudloff/openvegemap/master/taginfo.json
 osm2gtfs https://raw.githubusercontent.com/grote/osm2gtfs/master/taginfo.json
 osm2pgsql_default_c https://osmlab.github.io/osm2pgsql_taginfo/default_style.json
 osm2vectortiles https://raw.githubusercontent.com/osm2vectortiles/osm2vectortiles/master/taginfo.json


### PR DESCRIPTION
openvegemap is no longer being developed. [The GitHub repository](https://github.com/Rudloff/openvegemap) was archived a year ago.

Or does it still make sense to list such projects here?