### PR TITLE
Update Americana taginfo location

### DIFF
--- a/project_list.txt
+++ b/project_list.txt
@@ -138,7 +138,7 @@ osm2gtfs https://raw.githubusercontent.com/grote/osm2gtfs/master/taginfo.json
 osm2pgsql_default_c https://osmlab.github.io/osm2pgsql_taginfo/default_style.json
 osm2vectortiles https://raw.githubusercontent.com/osm2vectortiles/osm2vectortiles/master/taginfo.json
 osm2world http://osm2world.org/docs/taginfo/taginfo.json
-osm_americana https://zelonewolf.github.io/openstreetmap-americana/taginfo.json
+osm_americana https://americanamap.org/taginfo.json
 osm_carto_de https://raw.githubusercontent.com/giggls/openstreetmap-carto-de/master/views_osmde/taginfo.json
 osm_detailed_overlays https://raw.githubusercontent.com/twpol/osm-tiles/main/Documentation/taginfo.json
 osm_inspector_addresses https://raw.githubusercontent.com/ltog/osmi-addresses/master/taginfo.json


### PR DESCRIPTION
Update OSM-Americana taginfo address to use our new domain name.

CC/ ZeLonewolf/openstreetmap-americana#1128