### PR TITLE
allow the `$schema` field

### DIFF
--- a/taginfo-project-schema.json
+++ b/taginfo-project-schema.json
@@ -7,6 +7,11 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "$schema": {
+          "type": "string",
+          "format": "uri",
+          "description": "a url to the JSON schema used to validating this file"
+        },
         "data_format": {
           "type": "integer",
           "description": "data format version, currently always 1, will get updated if there are incompatible changes to the format"


### PR DESCRIPTION
follow-up to https://github.com/taginfo/taginfo-projects/pull/109#issuecomment-831076209, this PR adds `$schema` as an optional field to the schema.

Close #110