### PR TITLE
add evmap

### DIFF
--- a/project_list.txt
+++ b/project_list.txt
@@ -29,6 +29,7 @@ dianacht_topo https://geo.dianacht.de/topo/taginfo.json
 direction https://raw.githubusercontent.com/osmtools/direction/master/taginfo.json
 dk_etymology https://raw.githubusercontent.com/PeterBrodersen/osmetymology/main/taginfo.json
 dubious_tags_mk https://codeberg.org/matkoniecz/dubious_tags/raw/branch/master/tags_in_taginfo_format.json
+evmap https://raw.githubusercontent.com/ev-map/evmap/master/_misc/taginfo.json
 f4 https://raw.githubusercontent.com/angoca/f4demo-in-taginfo/refs/heads/main/taginfo.json
 fahrkartenautomaten https://raw.githubusercontent.com/ubahnverleih/OSMfahrkartenautomaten/master/taginfo.json
 flosm_cycling_map https://www.flosm.org/src/projects/cycling_map_taginfo.json


### PR DESCRIPTION
OSM charging stations will be included as a data source in EVMap's next release.

see:
- https://github.com/ev-map/EVMap/issues/97
- https://github.com/ev-map/EVMap/pull/290