### PR TITLE
OpenRailwayMap vector, use taginfo published on domain

### DIFF
--- a/project_list.txt
+++ b/project_list.txt
@@ -168,7 +168,7 @@ openlovemap_org https://openlovemap.org/taginfo.json
 opennwb https://raw.githubusercontent.com/FileradarBV/OpenNWB/master/taginfo.json
 opennwb_operators https://raw.githubusercontent.com/FileradarBV/OpenNWB/master/road-operators/taginfo.json
 openrailwaymap https://www.openrailwaymap.org/taginfo/taginfo.json
-openrailwaymap_vector https://raw.githubusercontent.com/hiddewie/OpenRailwayMap-vector/master/taginfo.json
+openrailwaymap_vector https://openrailwaymap.app/taginfo.json
 openskimap https://openskimap.org/taginfo.json
 opensnowmap_org https://www.opensnowmap.org/opensnowmap_taginfo.json
 openstop https://raw.githubusercontent.com/OPENER-next/OpenStop-taginfo/main/taginfo.json


### PR DESCRIPTION
With https://github.com/hiddewie/OpenRailwayMap-vector/pull/563, the `taginfo.json` will be published on the domain https://openrailwaymap.app/. It is automatically generated from other metadata in the project.

(draft until the change is merged and deployed)