### PR TITLE
feat: add Norwegian second hand portal

### DIFF
--- a/project_list.txt
+++ b/project_list.txt
@@ -33,6 +33,7 @@ evmap https://raw.githubusercontent.com/ev-map/evmap/master/_misc/taginfo.json
 f4 https://raw.githubusercontent.com/angoca/f4demo-in-taginfo/refs/heads/main/taginfo.json
 fahrkartenautomaten https://ubahnverleih.github.io/OSMfahrkartenautomaten/taginfo.json
 fileradar_traffic https://raw.githubusercontent.com/FileradarBV/OSM-Traffic-Taginfo/master/taginfo.json
+fivh_second_hand_portal https://fivh-bergen.github.io/kart/taginfo.json
 flosm_cycling_map https://www.flosm.org/src/projects/cycling_map_taginfo.json
 flosm_poi_map https://www.flosm.org/src/projects/poimap_taginfo.json
 flosm_public_transport https://www.flosm.org/src/projects/public_transport_taginfo.json


### PR DESCRIPTION
Adds a Norwegian project that displays second hand shops and related nodes

The website can be seen here:
https://fivh-bergen.github.io/kart/

JSON here:
https://fivh-bergen.github.io/kart/taginfo.json