### PR TITLE
Add Pelias Geocoder to taginfo projects

### DIFF
--- a/project_list.txt
+++ b/project_list.txt
@@ -218,6 +218,7 @@ paddlemap https://paddlemap.net/taginfo.json
 panopticity https://raw.githubusercontent.com/babastienne/PanoptiCity/main/taginfo.json
 parking_lanes https://raw.githubusercontent.com/zlant/parking-lanes/master/taginfo.json
 peakfinder https://fabiz.github.io/PeakFinder-API/osmtaginfo.json
+pelias https://cdn.jsdelivr.net/npm/pelias-openstreetmap/taginfo.json
 polygon_features https://raw.githubusercontent.com/tyrasd/osmtogeojson/taginfo/project.json
 power_grid https://www.flosm.org/src/projects/powergrid_taginfo.json
 pride_map https://raw.githubusercontent.com/Lumikeiju/pride-map/main/taginfo.json


### PR DESCRIPTION
This adds the [Pelias Geocoder](https://pelias.io/) tag usage to the projects list.