### PR TITLE
replace broken wikidata.org integration

### DIFF
--- a/project_list.txt
+++ b/project_list.txt
@@ -277,7 +277,7 @@ vrcholy https://vrcholy.onrender.com/taginfo.json
 wanderreitkarte https://www.wanderreitkarte.de/download/taginfo.json
 waterwaymap_org https://waterwaymap.org/taginfo.json
 waymarkedtrails https://static.waymarkedtrails.org/taginfo.json
-wikidata_org https://tools.wmflabs.org/wp-world/wikidata/tags.php
+wikidata_org https://raw.githubusercontent.com/k-yle/wikidata-taginfo-link/gh-pages/taginfo.json
 wuzzelmap https://wuzzelmap.ck.si/taginfo.json
 xctrails https://www.xctrails.org/taginfo.json
 yohours https://projets.pavie.info/yohours/taginfo.json


### PR DESCRIPTION
The existing URL for [wikidata.org](https://wikidata.org) has been broken for several months, see https://github.com/taginfo/taginfo/issues/480 for background info. "Broken" meaning that only the 3787 _tags_ are included in the taginfo project file, but all 846 _keys_ are missing ([example](https://taginfo.osm.org/keys/thw:rb#projects)), since _keys_ use the new property [`P13786`](http://www.wikidata.org/wiki/Property:P13786). 

Most tools that rely on these wikidata properties have already updated their code. However, this https://tools.wmflabs.org/wp-world/wikidata/tags.php script is still broken, and I [did not get a reply](https://de.wikipedia.org/w/index.php?title=Benutzer_Diskussion%3AKolossos&diff=261591486&oldid=261327378) from the maintainer, who seems to be [less active](https://xtools.wmcloud.org/globalcontribs/Kolossos) on wikipedia these days. The php code also appears to be closed source, and I can't find where/how/who could help to update it. 

As a (temporary?) solution, I've created a new script at [k-yle/wikidata-taginfo-link](https://github.com/k-yle/wikidata-taginfo-link) and updated the URL to point to this script... i'm not sure how else to solve this problem...